### PR TITLE
Fixed Croatian translation.

### DIFF
--- a/Resources/translations/messages.cr.yml
+++ b/Resources/translations/messages.cr.yml
@@ -1,15 +1,15 @@
 time_ago:
   past:
-    days: 'prije 4 dana'
+    days: 'prije # dana'
     now: 'upravo sad'
     minute: 'prije 1 minutu'
     minutes: 'prije # minuta'
     hour: 'prije # sat'
     hours: 'prije # sati'
   future:
-    days: 'u # dana'
+    days: 'za # dana'
     now: 'sada'
-    minute: 'u 1 minutu'
-    minutes: 'u # minuta'
-    hour: 'u 1 sati'
-    hours: 'u # sati'
+    minute: 'za 1 minutu'
+    minutes: 'za # minuta'
+    hour: 'za 1 sat'
+    hours: 'za # sati'


### PR DESCRIPTION
The days number was hardcoded so I fixed that and the strings for future times were a bit wrong so that is fixed as well.

The Croatian language should use the "hour" format for all numbers ending in 1,2,3 or 4, and "hours" formats for everything else but I guess this is out of the scope of the issue and would cause structural changes to the plugin if implemented.
