### PR TITLE
add czech translation

### DIFF
--- a/Resources/translations/messages.cs.yml
+++ b/Resources/translations/messages.cs.yml
@@ -1,0 +1,11 @@
+time_ago:
+  past:
+    days: '{1}před 1 dnem|]1,Inf]před # dny'
+    now: 'právě teď'
+    minutes: '{1}před minutou|]1,Inf]před # minutami'
+    hours: '{1}před hodinou|]1,Inf]před # hodinami'
+  future:
+    days: 'za den|za # dny|za # dní'
+    now: 'právě teď'
+    minutes: 'za minutu|za # minuty|za # minut'
+    hours: 'za hodinu|za # hodiny|za # hodin'


### PR DESCRIPTION
In Czech we use different format for the string 'in # hours' with values 2-4 and 5-inf. So it would be nice to change that to transchoice to have always the correct text.
