### PR TITLE
Not passing the root node name to TreeBuilder was deprecated

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,10 +17,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('eschmar_time_ago');
+        $treeBuilder = new TreeBuilder('eschmar_time_ago');
 
-        $rootNode
+        $treeBuilder->getRootNode()
             ->children()
                 ->scalarNode('format')
                     ->defaultValue('r')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,12 +12,19 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
+    const ROOT_NODE = 'eschmar_time_ago';
+
     /**
      * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder('eschmar_time_ago');
+        $treeBuilder = new TreeBuilder(static::ROOT_NODE);
+
+        // Symfony 4.2+
+        if (method_exists($treeBuilder, 'getRootNode')) $rootNode = $treeBuilder->getRootNode();
+        // Symfony 4.1 and below
+        else $rootNode = $treeBuilder->root(static::ROOT_NODE);
 
         $treeBuilder->getRootNode()
             ->children()


### PR DESCRIPTION
resolves issue #40 