### PR TITLE
Use DateTimeInterface instead of DateTime

### DIFF
--- a/Twig/TimeAgoExtension.php
+++ b/Twig/TimeAgoExtension.php
@@ -53,7 +53,7 @@ class TimeAgoExtension extends \Twig\Extension\AbstractExtension
      * @return string
      * @author Marcel Eschmann, @eschmar
      **/
-    public function agoFilter(\DateTime $date, $format = null)
+    public function agoFilter(\DateTimeInterface $date, $format = null)
     {
         $diff = time() - $date->format('U');
         $format = $format ? $format : $this->format;


### PR DESCRIPTION
Besides DateTime, DateTimeImmutable is used more and more in Symfony. 
Therefore it makes sense to set the type no longer explicitly to DateTime anymore.